### PR TITLE
Fix sticky header and enhance day selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ Ramówka Radia Meteor
 ## Getting Started
 
 Aplikacja ma służyć Radiu Meteor jako ramówka na stronę - punkt odniesienia dla tego co dzieje się aktualnie na antenie!
+
+### Konfiguracja źródła danych
+
+Dane ramówki pobierane są z publicznego arkusza Google Sheets. Id arkusza oraz nazwy zakładek dla tygodni A/B znajdują się w pliku `lib/data/services/google_sheet_service.dart` w mapie `sheetUrls`. Aby skorzystać z własnego arkusza należy podmienić tam adresy URL na własne.

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -1,0 +1,3 @@
+class AppConfig {
+  static const String appName = 'Ramówka';
+}

--- a/lib/config/theme_config.dart
+++ b/lib/config/theme_config.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class ThemeConfig {
+  static const Color primaryOrange = Color(0xFFFF6600);
+  static const Color darkGrey = Color(0xFF333333);
+  static const Color mediumGrey = Color(0xFF777777);
+  static const Color successGreen = Color(0xFF4CAF50);
+  static const Color errorRed = Color(0xFFE53935);
+  static const Color white = Colors.white;
+
+  static ThemeData get lightTheme => ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: primaryOrange),
+        useMaterial3: true,
+      );
+
+  static ThemeData get darkTheme => ThemeData.dark().copyWith(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: primaryOrange,
+          brightness: Brightness.dark,
+        ),
+        useMaterial3: true,
+      );
+}

--- a/lib/data/models/program.dart
+++ b/lib/data/models/program.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+class Program {
+  final String day;
+  final String startTime;
+  final String endTime;
+  final String title;
+  final String? hosts;
+  final String? description;
+  final String categoryName;
+  final String categoryColorHex;
+
+  Program({
+    required this.day,
+    required this.startTime,
+    required this.endTime,
+    required this.title,
+    this.hosts,
+    this.description,
+    this.categoryName = 'Program',
+    this.categoryColorHex = '#FF6600',
+  });
+
+  factory Program.fromJson(Map<String, dynamic> json) {
+    return Program(
+      day: json['day'] ?? '',
+      startTime: json['startTime'] ?? '',
+      endTime: json['endTime'] ?? '',
+      title: json['title'] ?? '',
+      hosts: json['hosts'],
+      description: json['description'],
+      categoryName: json['categoryName'] ?? 'Program',
+      categoryColorHex: json['categoryColorHex'] ?? '#FF6600',
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'day': day,
+      'startTime': startTime,
+      'endTime': endTime,
+      'title': title,
+      'hosts': hosts,
+      'description': description,
+      'categoryName': categoryName,
+      'categoryColorHex': categoryColorHex,
+    };
+  }
+
+  Color get categoryColor {
+    final hex = categoryColorHex.replaceAll('#', '');
+    return Color(int.parse('FF$hex', radix: 16));
+  }
+
+  String get timeRange => '$startTime - $endTime';
+
+  String get duration {
+    try {
+      final startParts = startTime.split(':').map(int.parse).toList();
+      final endParts = endTime.split(':').map(int.parse).toList();
+      final start = Duration(hours: startParts[0], minutes: startParts[1]);
+      final end = Duration(hours: endParts[0], minutes: endParts[1]);
+      var diff = end - start;
+      if (diff.isNegative) diff += const Duration(days: 1);
+      final h = diff.inHours;
+      final m = diff.inMinutes % 60;
+      return '${h}h ${m}min';
+    } catch (_) {
+      return '';
+    }
+  }
+
+  bool get isCurrentlyPlaying {
+    final now = DateTime.now();
+    const days = [
+      'Poniedziałek',
+      'Wtorek',
+      'Środa',
+      'Czwartek',
+      'Piątek',
+      'Sobota',
+      'Niedziela',
+    ];
+    final todayName = days[now.weekday - 1];
+    if (day != todayName) return false;
+    try {
+      final startParts = startTime.split(':').map(int.parse).toList();
+      final endParts = endTime.split(':').map(int.parse).toList();
+      final start = DateTime(now.year, now.month, now.day, startParts[0], startParts[1]);
+      DateTime end = DateTime(now.year, now.month, now.day, endParts[0], endParts[1]);
+      if (end.isBefore(start)) {
+        end = end.add(const Duration(days: 1));
+      }
+      return now.isAfter(start) && now.isBefore(end);
+    } catch (_) {
+      return false;
+    }
+  }
+}

--- a/lib/data/services/google_sheet_service.dart
+++ b/lib/data/services/google_sheet_service.dart
@@ -1,0 +1,141 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:csv/csv.dart';
+import '../models/program.dart';
+
+class GoogleSheetService {
+  static const sheetUrls = {
+    'Tydzień A': 'https://docs.google.com/spreadsheets/d/1nx3iG3qNFwYSr0Uj44M8OPZKliKeLz0R8s6QzJU22ao/gviz/tq?tqx=out:csv&sheet=Tydzień A',
+    'Tydzień B': 'https://docs.google.com/spreadsheets/d/1nx3iG3qNFwYSr0Uj44M8OPZKliKeLz0R8s6QzJU22ao/gviz/tq?tqx=out:csv&sheet=Tydzień B',
+  };
+
+  static Future<List<Program>> fetchSchedule(String week) async {
+    final url = sheetUrls[week];
+    if (url == null) throw Exception('Invalid week: $week');
+
+    final response = await http.get(Uri.parse(url));
+    if (response.statusCode != 200) {
+      throw Exception('Failed to load sheet');
+    }
+
+    final csvRaw = const Utf8Decoder().convert(response.bodyBytes);
+    final csvData = const CsvToListConverter().convert(csvRaw, eol: '\n');
+
+    if (csvData.isEmpty) return [];
+
+    final headers = csvData.first.cast<String>();
+    final godzinaIndex = headers.indexWhere((h) => h.trim().toLowerCase() == 'godzina');
+    if (godzinaIndex == -1) {
+      throw const FormatException('Brak kolumny Godzina w arkuszu');
+    }
+
+    final startTimes = <String>[];
+    final rows = <List<dynamic>>[];
+    for (int i = 1; i < csvData.length; i++) {
+      final row = csvData[i];
+      if (row.isEmpty) continue;
+      startTimes.add(row[godzinaIndex].toString());
+      rows.add(row);
+    }
+
+    final programs = <Program>[];
+    final lastIndexByDay = <String, int>{};
+
+    for (int i = 0; i < rows.length; i++) {
+      final row = rows[i];
+      final startTime = startTimes[i];
+      final endTime = i < startTimes.length - 1 ? startTimes[i + 1] : '00:00';
+
+      for (int j = godzinaIndex + 1; j < headers.length; j++) {
+        final day = headers[j];
+        final cell = j < row.length ? row[j]?.toString().trim() : '';
+
+        if (cell == null || cell.isEmpty) {
+          lastIndexByDay.remove(day);
+          continue;
+        }
+
+        var title = cell;
+        String? hosts;
+        if (cell.contains('–')) {
+          final parts = cell.split('–');
+          title = parts[0].trim();
+          hosts = parts.length > 1 ? parts[1].trim() : null;
+        }
+
+        final prevIndex = lastIndexByDay[day];
+        if (prevIndex != null) {
+          final prev = programs[prevIndex];
+          if (prev.title == title && (prev.hosts ?? '') == (hosts ?? '') &&
+              prev.endTime == startTime) {
+            programs[prevIndex] = Program(
+              day: day,
+              startTime: prev.startTime,
+              endTime: endTime,
+              title: title,
+              hosts: hosts,
+              categoryName: prev.categoryName,
+              categoryColorHex: prev.categoryColorHex,
+            );
+            lastIndexByDay[day] = prevIndex;
+            continue;
+          }
+        }
+
+        final program = Program(
+          day: day,
+          startTime: startTime,
+          endTime: endTime,
+          title: title,
+          hosts: hosts,
+          categoryName: 'Program',
+          categoryColorHex: '#FF6600',
+        );
+        programs.add(program);
+        lastIndexByDay[day] = programs.length - 1;
+      }
+    }
+
+    // Konsolidacja kolejnych identycznych wpisów na wypadek drobnych różnic w danych
+    List<Program> merged = [];
+    Program? last;
+    String normalize(String input) =>
+        input.toLowerCase().trim().replaceAll(RegExp(r'[–-]'), '-');
+
+    for (final p in programs) {
+      if (last != null &&
+          last.day == p.day &&
+          normalize(last.title) == normalize(p.title) &&
+          (last.hosts ?? '').trim() == (p.hosts ?? '').trim() &&
+          last.endTime == p.startTime) {
+        last = Program(
+          day: last.day,
+          startTime: last.startTime,
+          endTime: p.endTime,
+          title: last.title,
+          hosts: last.hosts,
+          categoryName: last.categoryName,
+          categoryColorHex: last.categoryColorHex,
+        );
+        merged[merged.length - 1] = last;
+      } else {
+        merged.add(p);
+        last = p;
+      }
+    }
+
+    // Zwracamy wynik po konsolidacji w obrębie pojedynczego dnia.
+    // Nie usuwamy identycznych wpisów pomiędzy różnymi dniami tygodnia,
+    // aby każdy dzień zachował swoją odrębną ramówkę.
+    return merged;
+  }
+
+  static Future<bool> testConnection() async {
+    try {
+      final response = await http.get(Uri.parse(sheetUrls.values.first));
+      return response.statusCode == 200;
+    } catch (_) {
+      return false;
+    }
+  }
+}

--- a/lib/presentation/screens/schedule_screen.dart
+++ b/lib/presentation/screens/schedule_screen.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import '../providers/schedule_provider.dart';
 import '../widgets/program_card.dart';
 import '../widgets/week_selector.dart';
+import '../widgets/day_selector.dart';
 import '../../config/theme_config.dart';
 
 class ScheduleScreen extends StatefulWidget {
@@ -13,7 +14,8 @@ class ScheduleScreen extends StatefulWidget {
   State<ScheduleScreen> createState() => _ScheduleScreenState();
 }
 
-class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStateMixin {
+class _ScheduleScreenState extends State<ScheduleScreen>
+    with TickerProviderStateMixin {
   late AnimationController _refreshController;
   late ScrollController _scrollController; // 🔥 DODANY SCROLL CONTROLLER
 
@@ -45,23 +47,27 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
   }
 
   // 🔥 NOWA METODA AUTO-SCROLL DO LIVE PROGRAMU
-  void _scrollToLiveProgram(List programs) {
+  void _scrollToLiveProgram(ScheduleProvider provider) {
+    final programs = provider.programsForSelectedDay;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!_scrollController.hasClients) return;
 
       // Znajdź indeks aktualnie granego programu
-      final liveIndex = programs.indexWhere((program) => program.isCurrentlyPlaying);
+      final liveIndex = programs.indexWhere(
+        (program) => provider.isProgramCurrentlyPlaying(program),
+      );
 
       if (liveIndex != -1) {
         debugPrint('🎯 Przewijam do Live programu na pozycji: $liveIndex');
 
         // Wysokość jednej karty programu (szacunkowo)
         const itemHeight = 120.0;
-        const headerHeight = 200.0; // Wysokość stats header
+        const headerHeight = 260.0; // Wysokość sklejonych nagłówków
 
         // Oblicz pozycję scroll - wyśrodkuj live program
         final screenHeight = MediaQuery.of(context).size.height;
-        final targetPosition = (liveIndex * itemHeight) + headerHeight - (screenHeight / 3);
+        final targetPosition =
+            (liveIndex * itemHeight) + headerHeight - (screenHeight / 3);
 
         // Animowane przewijanie do live programu
         _scrollController.animateTo(
@@ -137,9 +143,9 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
 
           case ScheduleState.loaded:
           case ScheduleState.refreshing:
-          // 🔥 AUTO-SCROLL PO ZAŁADOWANIU DANYCH
-            if (provider.programs.isNotEmpty) {
-              _scrollToLiveProgram(provider.programs);
+            // 🔥 AUTO-SCROLL PO ZAŁADOWANIU DANYCH
+            if (provider.programsForSelectedDay.isNotEmpty) {
+              _scrollToLiveProgram(provider);
             }
             return _buildLoadedState(provider);
 
@@ -162,10 +168,7 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
           SizedBox(height: 16),
           Text(
             'Ładowanie ramówki...',
-            style: TextStyle(
-              fontSize: 16,
-              color: ThemeConfig.mediumGrey,
-            ),
+            style: TextStyle(fontSize: 16, color: ThemeConfig.mediumGrey),
           ),
         ],
       ),
@@ -194,10 +197,7 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
             const SizedBox(height: 24),
             const Text(
               'Błąd ładowania ramówki',
-              style: TextStyle(
-                fontSize: 20,
-                fontWeight: FontWeight.bold,
-              ),
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 8),
@@ -243,13 +243,23 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
       child: CustomScrollView(
         controller: _scrollController, // 🔥 PODŁĄCZONY SCROLL CONTROLLER
         slivers: [
-          _buildStatsHeader(provider),
-          _buildCurrentProgramHeader(provider),
+          SliverPersistentHeader(
+            pinned: true,
+            delegate: _StickyHeaderDelegate(
+              child: _buildStatsHeader(provider),
+              height: 180,
+            ),
+          ),
+          SliverPersistentHeader(
+            pinned: true,
+            delegate: _StickyHeaderDelegate(
+              child: _buildCurrentProgramHeader(provider),
+              height: provider.currentProgram != null ? 120 : 0,
+            ),
+          ),
           _buildProgramsList(provider),
           // 🔥 DODATKOWY PADDING NA DOLE
-          const SliverToBoxAdapter(
-            child: SizedBox(height: 100),
-          ),
+          const SliverToBoxAdapter(child: SizedBox(height: 100)),
         ],
       ),
     );
@@ -277,18 +287,12 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
             const SizedBox(height: 24),
             const Text(
               'Brak programów w ramówce',
-              style: TextStyle(
-                fontSize: 18,
-                fontWeight: FontWeight.bold,
-              ),
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 8),
             const Text(
               'Sprawdź konfigurację Google Sheets lub spróbuj później',
-              style: TextStyle(
-                fontSize: 14,
-                color: ThemeConfig.mediumGrey,
-              ),
+              style: TextStyle(fontSize: 14, color: ThemeConfig.mediumGrey),
               textAlign: TextAlign.center,
             ),
           ],
@@ -298,64 +302,73 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
   }
 
   Widget _buildStatsHeader(ScheduleProvider provider) {
-    return SliverToBoxAdapter(
-      child: Container(
-        margin: const EdgeInsets.all(16),
-        padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: [
-              ThemeConfig.primaryOrange,
-              ThemeConfig.primaryOrange.withOpacity(0.8),
-            ],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
+    return Container(
+      margin: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            ThemeConfig.primaryOrange,
+            ThemeConfig.primaryOrange.withOpacity(0.8),
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: ThemeConfig.primaryOrange.withOpacity(0.3),
+            blurRadius: 8,
+            offset: const Offset(0, 4),
           ),
-          borderRadius: BorderRadius.circular(16),
-          boxShadow: [
-            BoxShadow(
-              color: ThemeConfig.primaryOrange.withOpacity(0.3),
-              blurRadius: 8,
-              offset: const Offset(0, 4),
-            ),
-          ],
-        ),
-        child: Row(
-          children: [
-            Expanded(
-              child: _buildStatItem(
-                'Programy',
-                provider.totalPrograms.toString(),
-                Icons.radio,
+        ],
+      ),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: _buildStatItem(
+                  'Programy',
+                  provider.totalPrograms.toString(),
+                  Icons.radio,
+                ),
               ),
-            ),
-            Container(
-              width: 1,
-              height: 40,
-              color: Colors.white.withOpacity(0.3),
-            ),
-            Expanded(
-              child: _buildStatItem(
-                'Czas antenowy',
-                provider.totalDuration,
-                Icons.schedule,
+              Container(
+                width: 1,
+                height: 40,
+                color: Colors.white.withOpacity(0.3),
               ),
-            ),
-            Container(
-              width: 1,
-              height: 40,
-              color: Colors.white.withOpacity(0.3),
-            ),
-            // 🔥 DODATKOWA STATYSTYKA - AKTUALNY TYDZIEŃ
-            Expanded(
-              child: _buildStatItem(
-                'Tydzień',
-                provider.selectedWeek.replaceAll('Tydzień ', ''),
-                provider.selectedWeek == 'Tydzień A' ? Icons.looks_one : Icons.looks_two,
+              Expanded(
+                child: _buildStatItem(
+                  'Czas antenowy',
+                  provider.totalDuration,
+                  Icons.schedule,
+                ),
               ),
-            ),
-          ],
-        ),
+              Container(
+                width: 1,
+                height: 40,
+                color: Colors.white.withOpacity(0.3),
+              ),
+              // 🔥 DODATKOWA STATYSTYKA - AKTUALNY TYDZIEŃ
+              Expanded(
+                child: _buildStatItem(
+                  'Tydzień',
+                  provider.selectedWeek.replaceAll('Tydzień ', ''),
+                  provider.selectedWeek == 'Tydzień A'
+                      ? Icons.looks_one
+                      : Icons.looks_two,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          DaySelector(
+            selectedDay: provider.selectedDay,
+            onDayChanged: provider.changeDay,
+          ),
+        ],
       ),
     );
   }
@@ -363,11 +376,7 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
   Widget _buildStatItem(String label, String value, IconData icon) {
     return Column(
       children: [
-        Icon(
-          icon,
-          color: Colors.white,
-          size: 20,
-        ),
+        Icon(icon, color: Colors.white, size: 20),
         const SizedBox(height: 6),
         Text(
           value,
@@ -379,10 +388,7 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
         ),
         Text(
           label,
-          style: const TextStyle(
-            color: Colors.white70,
-            fontSize: 10,
-          ),
+          style: const TextStyle(color: Colors.white70, fontSize: 10),
         ),
       ],
     );
@@ -391,94 +397,90 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
   Widget _buildCurrentProgramHeader(ScheduleProvider provider) {
     final currentProgram = provider.currentProgram;
 
-    if (currentProgram == null) return const SliverToBoxAdapter(child: SizedBox.shrink());
+    if (currentProgram == null) {
+      return const SizedBox.shrink();
+    }
 
-    return SliverToBoxAdapter(
-      child: Container(
-        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        child: Card(
-          color: ThemeConfig.successGreen,
-          elevation: 8, // 🔥 PODWYŻSZONA ELEVACJA DLA LIVE PROGRAMU
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Row(
-              children: [
-                Container(
-                  padding: const EdgeInsets.all(8),
-                  decoration: BoxDecoration(
-                    color: Colors.white.withOpacity(0.2),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: const Icon(
-                    Icons.radio,
-                    color: Colors.white,
-                    size: 24,
-                  ),
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Card(
+        color: ThemeConfig.successGreen,
+        elevation: 8, // 🔥 PODWYŻSZONA ELEVACJA DLA LIVE PROGRAMU
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  color: Colors.white.withOpacity(0.2),
+                  borderRadius: BorderRadius.circular(8),
                 ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        children: [
-                          const Text(
-                            'TERAZ NA ANTENIE',
-                            style: TextStyle(
-                              color: Colors.white70,
-                              fontSize: 12,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          // 🔥 ANIMOWANA KROPKA LIVE
-                          Container(
-                            width: 8,
-                            height: 8,
-                            decoration: BoxDecoration(
-                              color: Colors.red,
-                              shape: BoxShape.circle,
-                              boxShadow: [
-                                BoxShadow(
-                                  color: Colors.red.withOpacity(0.6),
-                                  blurRadius: 4,
-                                  spreadRadius: 1,
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        currentProgram.title,
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 16,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      if (currentProgram.hosts?.isNotEmpty == true)
-                        Text(
-                          currentProgram.hosts!,
-                          style: const TextStyle(
+                child: const Icon(Icons.radio, color: Colors.white, size: 24),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        const Text(
+                          'TERAZ NA ANTENIE',
+                          style: TextStyle(
                             color: Colors.white70,
-                            fontSize: 14,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
                           ),
                         ),
-                    ],
-                  ),
+                        const SizedBox(width: 8),
+                        // 🔥 ANIMOWANA KROPKA LIVE
+                        Container(
+                          width: 8,
+                          height: 8,
+                          decoration: BoxDecoration(
+                            color: Colors.red,
+                            shape: BoxShape.circle,
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.red.withOpacity(0.6),
+                                blurRadius: 4,
+                                spreadRadius: 1,
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      currentProgram.title,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    if (currentProgram.hosts?.isNotEmpty == true)
+                      Text(
+                        currentProgram.hosts!,
+                        style: const TextStyle(
+                          color: Colors.white70,
+                          fontSize: 14,
+                        ),
+                      ),
+                  ],
                 ),
-                Text(
-                  currentProgram.timeRange,
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 14,
-                    fontWeight: FontWeight.w600,
-                  ),
+              ),
+              Text(
+                currentProgram.timeRange,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ),
@@ -486,19 +488,17 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
   }
 
   Widget _buildProgramsList(ScheduleProvider provider) {
+    final programs = provider.programsForSelectedDay;
     return SliverPadding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
       sliver: SliverList(
-        delegate: SliverChildBuilderDelegate(
-              (context, index) {
-            final program = provider.programs[index];
-            return ProgramCard(
-              program: program,
-              isCurrentlyPlaying: program.isCurrentlyPlaying,
-            );
-          },
-          childCount: provider.programs.length,
-        ),
+        delegate: SliverChildBuilderDelegate((context, index) {
+          final program = programs[index];
+          return ProgramCard(
+            program: program,
+            isCurrentlyPlaying: provider.isProgramCurrentlyPlaying(program),
+          );
+        }, childCount: programs.length),
       ),
     );
   }
@@ -522,7 +522,9 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
 
         return FloatingActionButton(
           onPressed: () {
-            _refreshController.forward().then((_) => _refreshController.reset());
+            _refreshController.forward().then(
+              (_) => _refreshController.reset(),
+            );
             provider.refresh();
           },
           tooltip: 'Odśwież ramówkę',
@@ -547,17 +549,11 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
         padding: EdgeInsets.zero,
         children: [
           const DrawerHeader(
-            decoration: BoxDecoration(
-              color: ThemeConfig.primaryOrange,
-            ),
+            decoration: BoxDecoration(color: ThemeConfig.primaryOrange),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Icon(
-                  Icons.radio,
-                  color: Colors.white,
-                  size: 48,
-                ),
+                Icon(Icons.radio, color: Colors.white, size: 48),
                 SizedBox(height: 16),
                 Text(
                   'Ramówka Radiowa',
@@ -569,10 +565,7 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
                 ),
                 Text(
                   'Profesjonalna aplikacja ramówki',
-                  style: TextStyle(
-                    color: Colors.white70,
-                    fontSize: 14,
-                  ),
+                  style: TextStyle(color: Colors.white70, fontSize: 14),
                 ),
               ],
             ),
@@ -625,7 +618,9 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
               return ListTile(
                 leading: Icon(
                   Icons.radio,
-                  color: hasLiveProgram ? ThemeConfig.successGreen : ThemeConfig.mediumGrey,
+                  color: hasLiveProgram
+                      ? ThemeConfig.successGreen
+                      : ThemeConfig.mediumGrey,
                 ),
                 title: Text(
                   hasLiveProgram ? 'Przejdź do Live' : 'Brak Live programu',
@@ -633,10 +628,12 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
                     color: hasLiveProgram ? null : ThemeConfig.mediumGrey,
                   ),
                 ),
-                onTap: hasLiveProgram ? () {
-                  Navigator.pop(context);
-                  _scrollToLiveProgram(provider.programs);
-                } : null,
+                onTap: hasLiveProgram
+                    ? () {
+                        Navigator.pop(context);
+                        _scrollToLiveProgram(provider);
+                      }
+                    : null,
               );
             },
           ),
@@ -674,12 +671,11 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
               style: TextStyle(fontWeight: FontWeight.bold),
             ),
             SizedBox(height: 8),
-            Text('Profesjonalna aplikacja do zarządzania ramówką radiową z integracją Google Sheets.'),
-            SizedBox(height: 16),
             Text(
-              'Funkcje:',
-              style: TextStyle(fontWeight: FontWeight.bold),
+              'Profesjonalna aplikacja do zarządzania ramówką radiową z integracją Google Sheets.',
             ),
+            SizedBox(height: 16),
+            Text('Funkcje:', style: TextStyle(fontWeight: FontWeight.bold)),
             Text('• Integracja z Google Sheets'),
             Text('• Auto-scroll do Live programu'),
             Text('• Przełączanie między tygodniami A/B'),
@@ -781,7 +777,9 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Wyczyść cache'),
-        content: const Text('Czy na pewno chcesz wyczyścić zapisane dane? Aplikacja pobierze je ponownie z Google Sheets.'),
+        content: const Text(
+          'Czy na pewno chcesz wyczyścić zapisane dane? Aplikacja pobierze je ponownie z Google Sheets.',
+        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),
@@ -805,6 +803,37 @@ class _ScheduleScreenState extends State<ScheduleScreen> with TickerProviderStat
         ],
       ),
     );
+  }
+}
+
+class _StickyHeaderDelegate extends SliverPersistentHeaderDelegate {
+  final Widget child;
+  final double height;
+
+  _StickyHeaderDelegate({required this.child, required this.height});
+
+  @override
+  double get minExtent => height;
+
+  @override
+  double get maxExtent => height;
+
+  @override
+  Widget build(
+    BuildContext context,
+    double shrinkOffset,
+    bool overlapsContent,
+  ) {
+    return Material(
+      color: Theme.of(context).scaffoldBackgroundColor,
+      elevation: overlapsContent ? 2 : 0,
+      child: child,
+    );
+  }
+
+  @override
+  bool shouldRebuild(covariant _StickyHeaderDelegate oldDelegate) {
+    return oldDelegate.child != child || oldDelegate.height != height;
   }
 }
 

--- a/lib/presentation/widgets/day_selector.dart
+++ b/lib/presentation/widgets/day_selector.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import '../../config/theme_config.dart';
+
+class DaySelector extends StatelessWidget {
+  final String selectedDay;
+  final ValueChanged<String> onDayChanged;
+
+  const DaySelector({super.key, required this.selectedDay, required this.onDayChanged});
+
+  static const List<String> days = [
+    'Poniedziałek',
+    'Wtorek',
+    'Środa',
+    'Czwartek',
+    'Piątek',
+    'Sobota',
+    'Niedziela',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final today = days[DateTime.now().weekday - 1];
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: days.map((day) {
+          final bool isSelected = day == selectedDay;
+          final bool isToday = day == today;
+          return Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 4),
+            child: ChoiceChip(
+              label: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    day.substring(0, 3),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (isToday) ...[
+                    const SizedBox(width: 4),
+                    Container(
+                      width: 6,
+                      height: 6,
+                      decoration: const BoxDecoration(
+                        color: Colors.red,
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+              selected: isSelected,
+              onSelected: (_) => onDayChanged(day),
+              selectedColor: ThemeConfig.primaryOrange,
+              backgroundColor: ThemeConfig.darkGrey.withOpacity(0.05),
+              labelStyle: TextStyle(
+                color: isSelected ? Colors.white : ThemeConfig.darkGrey,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
+  csv:
+    dependency: "direct main"
+    description:
+      name: csv
+      sha256: c6aa2679b2a18cb57652920f674488d89712efaf4d3fdf2e537215b35fc19d6c
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
   cupertino_icons:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   intl: ^0.19.0
   google_fonts: ^5.0.0
   shared_preferences: ^2.2.2
+  csv: ^6.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- ensure sticky headers rebuild when provider updates
- wrap sticky headers with a Material background
- adjust header heights to prevent overflow
- show a red dot on today's day in the day selector

## Testing
- `flutter --version` *(fails: command not found)*
- `dart format lib/presentation/screens/schedule_screen.dart lib/presentation/widgets/day_selector.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846f7ba9a0c83258af55ea1f8a9bfef